### PR TITLE
Fix problem from upgrading hugo, ignore new public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .hugo_build.lock
+public

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,7 +2,6 @@
 <ignore-format>
     {{ partial "list-page-title" . }}
 </ignore-format>
-<!-- {{ partial "site-tag-list" . }} -->
 
 <ignore-format>
     {{ $paginator := .Paginate (where .Pages "Type" "blog") 10 }}


### PR DESCRIPTION
Releases have failed because the GHA for releases pulled the latest hugo version, and there was a build error specific to the newer version used in GitHub vs locally.