### PR TITLE
Style and asset fixes

### DIFF
--- a/assets/sass/blog/post.scss
+++ b/assets/sass/blog/post.scss
@@ -28,21 +28,28 @@
     font-size: 1.75rem;
 }
 
-.blog-post img {
-    width: 100%;
-}
-
 .blog-post figure {
     display: flex;
     flex-direction: column;
     justify-content: center;
+    align-items: center;
+    margin: 0;
+    margin-top: 2rem;
     margin-bottom: 2rem;
+
+    & img {
+        width: 100%;
+        margin-bottom: 1rem;
+    }
 
     & figcaption {
         text-align: center;
         font-size: 90%;
         font-style: italic;
+        width: 100%;
     }
+
+
 }
 
 .blog-post p a,
@@ -58,5 +65,17 @@
     &:hover {
         text-decoration: none;
         color: var(--yellow);
+    }
+}
+
+@media (min-width: $breakpoint-tablet) {
+    .blog-post figure img {
+        width: 50%;
+    }
+}
+
+@media (min-width: $breakpoint-tablet) {
+    .blog-post figure figcaption {
+        width: 60%;
     }
 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,8 +1,4 @@
 ---
-title: "Home"
-menu:
-  main:
-    weight: 100
 introduction:
   heading: "Hi I'm Sarah"
   paragraphs: [

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,56 +1,57 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <!-- <script src="https://cdn.tailwindcss.com"></script> -->
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
-    </style>
-    {{ $sass := resources.Get "sass/main.scss" | resources.ToCSS}}
-    <link rel="stylesheet" href="{{ $sass.Permalink }}">
-    <script>
-        // Adapted from: https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <!-- <script src="https://cdn.tailwindcss.com"></script> -->
+        <style>
+            @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+        </style>
+        {{ $sass := resources.Get "sass/main.scss" | resources.ToCSS}}
+        <link rel="stylesheet" href="{{ $sass.Permalink }}">
+        <base href="{{ .Site.BaseURL }}">
+        <script>
+            // Adapted from: https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
 
-        document.addEventListener("DOMContentLoaded", () =>{
-            // get the sticky element
-            const el = document.querySelector('#menu')
-            
-            const observer = new IntersectionObserver(
-                // callback argument
-                (entries, observer) => {
-                    console.log("callback fired")
-                    const e = entries[0]
-                    e.target.classList.toggle('nav--pinned', e.intersectionRatio < 1)
-                },
-                // options
-                {
-                    threshold: [1]
-                }
-            );
-                
-            observer.observe(el)
-        })
-    </script>
+            document.addEventListener("DOMContentLoaded", () => {
+                // get the sticky element
+                const el = document.querySelector('#menu')
 
-    <title>
-        {{.Page.Title}} | {{ .Site.Title }}
-    </title>
-</head>
+                const observer = new IntersectionObserver(
+                    // callback argument
+                    (entries, observer) => {
+                        console.log("callback fired")
+                        const e = entries[0]
+                        e.target.classList.toggle('nav--pinned', e.intersectionRatio < 1)
+                    },
+                    // options
+                    {
+                        threshold: [1]
+                    }
+                );
 
-<body>
-    {{partial "menu" .}}
-    {{ block "hero" . }}
-    {{ end }}
-    <div class="main-wrapper  {{ if .IsHome }}main-wrapper--home{{else}}main-wrapper--subpage{{end}}">
-        <main class="main-content">
-            {{ block "main" . }}
-            {{ end }}
-        </main>
-    </div>
-    
-    {{partial "footer"}}
-</body>
+                observer.observe(el)
+            })
+        </script>
+
+        <title>
+            {{.Page.Title}} | {{ .Site.Title }}
+        </title>
+    </head>
+
+    <body>
+        {{partial "menu" .}}
+        {{ block "hero" . }}
+        {{ end }}
+        <div class="main-wrapper  {{ if .IsHome }}main-wrapper--home{{else}}main-wrapper--subpage{{end}}">
+            <main class="main-content">
+                {{ block "main" . }}
+                {{ end }}
+            </main>
+        </div>
+
+        {{partial "footer"}}
+    </body>
 
 </html>


### PR DESCRIPTION
This PR:
- Updates styles on figure image and captions - more margins, width of images are responsive now, and put non-mobile/media query styles at the end of the file as they have equal specificity as the mobile/default rules
- Makes it so relative URLs all use the same base URL
-  Removes duplicate declaration of menu items. These can be defined in multiple places (front matter, config.json, etc) so this PR consolidates to config.json.